### PR TITLE
Adding sandworm script and GitHub Action

### DIFF
--- a/.github/workflows/sandworm.yml
+++ b/.github/workflows/sandworm.yml
@@ -1,0 +1,20 @@
+name: 'Sandworm'
+on:
+    pull_request:
+        branches:
+            - main
+jobs:
+    audit:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup Node.js
+              uses: actions/setup-node@v3
+              with:
+                node-version: "16"
+                
+            # Run sandworm-audit via npm script in package.json
+            - name: Run audit
+              id: sandworm-audit
+              run: npm run sca
+            

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
+/sandworm
+
 # dependencies
 /node_modules
 /.pnp

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test": "jest",
     "test-watch": "jest --watch",
-    "coverage": "jest --collectCoverage --"
+    "coverage": "jest --collectCoverage --",
+    "sca": "npx @sandworm/audit@latest"
   },
   "dependencies": {
     "autoprefixer": "10.4.14",


### PR DESCRIPTION
Sandworm provides a minimal amount of "SCA coverage" for the repo.